### PR TITLE
Updates to the object matching from causing the player to break.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,14 +187,13 @@ const onMediaInfo = (tracks, abr) => {
         audioQElement.disabled = false;
       }
       if (content === "audio") {
-        const { track_id, params } = track;
-        const { sample_rate } = params;
+        const { track_id, sample_rate } = track;
         const option = document.createElement("option");
         option.value = track_id;
         option.text = `${sample_rate} kbps`;
         audioQElement.add(option, null);
       } else if (content === "video") {
-        const { track_id, params } = track;
+        const { track_id } = track;
         const { width = "", height = "" } = params;
         const option = document.createElement("option");
         option.value = track_id;


### PR DESCRIPTION
These calls were breaking the player and causing it to reload over and over until it eventually would stop attempting to play the video.